### PR TITLE
Use same ID selection logic for rootId

### DIFF
--- a/js/graph.js
+++ b/js/graph.js
@@ -28,7 +28,7 @@ Vizu.Graph.prototype = (function () {
         group = getGroup(n, this.options),
         node;
       if (0 === n.dist) {
-        this.rootId = i;
+        this.rootId = this.options.data.properties.id ? n[this.options.data.properties.id] : i,
       }
       node = {
         // we use the count of the loop as an id if the id property setting is false


### PR DESCRIPTION
This uses the same logic for the root node ID as for the node ID. 
