### PR TITLE
Fix chop function

### DIFF
--- a/dist/vis-custom.js
+++ b/dist/vis-custom.js
@@ -3413,7 +3413,7 @@ function newSyntaxError(message) {
  * @returns {String}
  */
 function chop(text, maxLength) {
-  return text.length <= maxLength ? text : text.substr(0, 27) + '...';
+  return text.length <= maxLength ? text : text.substr(0, maxLength-3) + '...';
 }
 
 /**


### PR DESCRIPTION
The chop length seems to be hardcoded to 27, ignoring the maxLength parameter.

I believe the intention is normally for the maxLength to be 30, and we take away 3 from the maxLength to accomodate the `...`. I'm not sure where this is used but noticed when trying to resolve another issue :)
