### PR TITLE
Prevent ellipsis when statusContainer overflows

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -246,9 +246,8 @@ ul.context-menu li.disabled, ul.context-menu li.disabled:hover {
 
 #statusContainer {
     display: inline-block;
-    overflow: hidden;
+    overflow: auto;
     word-wrap: break-word;
-    text-overflow: ellipsis;
     max-width: 100%;
     white-space: nowrap;
 }


### PR DESCRIPTION
Currently if the statusBar contains a string which is too long to display it replaces the whole text with `...`.

When hovering over an especially long relationship and node combination this means it is impossible to see what it actually means. 

There might be better ways to resolve this, but this worked for me.
