### PR TITLE
Stop after stablization

### DIFF
--- a/dist/vis-custom.js
+++ b/dist/vis-custom.js
@@ -10372,7 +10372,9 @@ var PhysicsEngine = (function () {
       if (this.stabilized === true) {
         this._emitStabilized();
       } else {
-        this.startSimulation();
+        // Prevent large complicated graphs from buzzing around after
+        // stabilization.
+        //this.startSimulation();
       }
 
       this.ready = true;


### PR DESCRIPTION
When viewing large graphs, and stabilization fails to complete, the graph can buzz around annoyingly. 

Often this causes a lot of CPU usage and it can be painful to turn off physics manually. 
