### PR TITLE
Fix error when displaying a graph with id properties

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -43,8 +43,8 @@ Vizu.options = {
   data: {
     properties: {
       nodes: {
-        // How edges reference nodes: False is loop order-based id, true is id from node property
-        id: true,
+        // how edges reference nodes: false is loop order-based id, 'id property name' is id from node property
+        id: 'id',
         group: 'type',
         title: 'name',
         short: 'shortname',

--- a/js/graph.js
+++ b/js/graph.js
@@ -28,13 +28,13 @@ Vizu.Graph.prototype = (function () {
         group = getGroup(n, this.options),
         node;
       if (0 === n.dist) {
-        this.rootId = this.options.data.properties.id ? n[this.options.data.properties.id] : i
+        this.rootId = this.options.data.properties.nodes.id ? n[this.options.data.properties.nodes.id] : i
       }
       node = {
         // we use the count of the loop as an id if the id property setting is false
         // this is in case the edges properties "from" and "to" are referencing
         // the order of the node, not the real id.
-        id: this.options.data.properties.id ? n[this.options.data.properties.id] : i,
+        id: this.options.data.properties.nodes.id ? n[this.options.data.properties.nodes.id] : i,
         group: group,
         baseGroup: group,
         title: n[this.options.data.properties.nodes.title],


### PR DESCRIPTION
In graph.js, this.options.data.properties.id doesn't exist. It's this.options.data.properties.nodes.id.

In config.js, id must be false or the id property name, not true.